### PR TITLE
Preprocessing in python

### DIFF
--- a/Example - Suggest Online.ipynb
+++ b/Example - Suggest Online.ipynb
@@ -17,7 +17,16 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "from moz_preprocess.bq_utils import fetch_weekly_aggregate"
+    "from moz_preprocess.bq_utils import fetch_weekly_aggregate\n",
+    "from moz_preprocess.preprocess import preprocess"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "637dd514",
+   "metadata": {},
+   "source": [
+    "# Fetch data from BigQuery"
    ]
   },
   {
@@ -38,7 +47,9 @@
    "outputs": [],
    "source": [
     "# This will take a few minutes to run.\n",
-    "df = fetch_weekly_aggregate(\n",
+    "sample = 30000\n",
+    "\n",
+    "df_from_bq = fetch_weekly_aggregate(\n",
     "    week_start_date=\"2023-01-15\",  # Choose a different start date to avoid lunar new year.\n",
     "    segment=\"\"\"\n",
     "    CASE WHEN user_pref_browser_urlbar_quicksuggest_data_collection_enabled = 'true'\n",
@@ -47,7 +58,7 @@
     "         END\n",
     "    \"\"\",\n",
     "    target=\"country = 'US' and normalized_channel = 'release' and locale like 'en%'\",\n",
-    "    sample=10000,  # The dataset is 15 million rows without sampling.\n",
+    "    sample=sample,  # The dataset is 15 million rows without sampling.\n",
     "    verbose=False  # Set True to see the SQL that is run.\n",
     ")  "
    ]
@@ -72,7 +83,130 @@
     }
    ],
    "source": [
-    "df.segment.value_counts()"
+    "df_from_bq.segment.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "909d0fff",
+   "metadata": {},
+   "source": [
+    "# Preprocess data for difference-finder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56f7f916",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cols_to_drop = [\n",
+    "    # To Do: don't drop these fields. preprocess them instead.\n",
+    "    \"attribution\",\n",
+    "    \"browser_version_info\",\n",
+    "    \"active_addons\",\n",
+    "    \"a11y_theme\",\n",
+    "    \"experiments\",\n",
+    "    \"scalar_parent_browser_ui_interaction_content_context_sum\",\n",
+    "    \"scalar_parent_browser_ui_interaction_preferences_pane_home_sum\",\n",
+    "    \"scalar_parent_devtools_accessibility_select_accessible_for_node_sum\",\n",
+    "]\n",
+    "discrete_cols = [\n",
+    "  \"addon_compatibility_check_enabled\",\n",
+    "  \"app_display_version\",\n",
+    "  \"blocklist_enabled\",\n",
+    "  \"cpu_cores\",\n",
+    "  \"cpu_count\",\n",
+    "  \"cpu_family\",\n",
+    "  \"cpu_l2_cache_kb\",\n",
+    "  \"cpu_l3_cache_kb\",\n",
+    "  \"cpu_model\",\n",
+    "  \"cpu_speed_mhz\",\n",
+    "  \"cpu_stepping\",\n",
+    "  \"cpu_vendor\",\n",
+    "  \"default_search_engine_data_name\",\n",
+    "  \"distribution_id\",\n",
+    "  \"e10s_enabled\",\n",
+    "  \"env_build_arch\",\n",
+    "  \"flash_version\",\n",
+    "  \"country\",\n",
+    "  \"city\",\n",
+    "  \"geo_subdivision1\",\n",
+    "  \"geo_subdivision2\",\n",
+    "  \"isp_name\",\n",
+    "  \"isp_organization\",\n",
+    "  \"gfx_features_advanced_layers_status\",\n",
+    "  \"gfx_features_d2d_status\",\n",
+    "  \"gfx_features_d3d11_status\",\n",
+    "  \"gfx_features_gpu_process_status\",\n",
+    "  \"install_year\",\n",
+    "  \"is_default_browser\",\n",
+    "  \"is_wow64\",\n",
+    "  \"locale\",\n",
+    "  \"memory_mb\",\n",
+    "  \"normalized_channel\",\n",
+    "  \"normalized_os_version\",\n",
+    "  \"os\",\n",
+    "  \"os_version\",\n",
+    "  \"sandbox_effective_content_process_level\",\n",
+    "  \"sync_configured\",\n",
+    "  \"telemetry_enabled\",\n",
+    "  \"timezone_offset\",\n",
+    "  \"update_auto_download\",\n",
+    "  \"update_channel\",\n",
+    "  \"update_enabled\",\n",
+    "  \"vendor\",\n",
+    "  \"windows_build_number\",\n",
+    "  \"windows_ubr\",\n",
+    "  \"fxa_configured\",\n",
+    "  \"scalar_parent_os_environment_is_taskbar_pinned\",\n",
+    "  \"scalar_parent_os_environment_launched_via_desktop\",\n",
+    "  \"scalar_parent_os_environment_launched_via_taskbar\",\n",
+    "  \"scalar_parent_os_environment_launched_via_other\",\n",
+    "  \"scalar_parent_os_environment_launched_via_start_menu\",\n",
+    "  \"scalar_parent_os_environment_launched_via_other_shortcut\",\n",
+    "  \"default_private_search_engine\",\n",
+    "  \"user_pref_browser_search_region\",\n",
+    "  \"update_background\",\n",
+    "  \"user_pref_browser_urlbar_suggest_searches\",\n",
+    "  \"user_pref_browser_newtabpage_enabled\",\n",
+    "  \"user_pref_app_shield_optoutstudies_enabled\",\n",
+    "  \"scalar_parent_os_environment_launched_via_taskbar_private\",\n",
+    "  \"dom_parentprocess_private_window_used\",\n",
+    "  \"os_environment_is_taskbar_pinned_any\",\n",
+    "  \"os_environment_is_taskbar_pinned_private_any\",\n",
+    "  \"os_environment_is_taskbar_pinned_private\",\n",
+    "  \"search_cohort\",\n",
+    "  \"user_pref_browser_urlbar_quicksuggest_data_collection_enabled\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c39f5544",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dummies = []\n",
+    "for col in discrete_cols:\n",
+    "    dummies.append(preprocess(df_from_bq[col], col, int(0.01*sample)))\n",
+    "\n",
+    "df = pd.concat([df_from_bq.drop(cols_to_drop + discrete_cols, axis=1)] + [x for x in dummies if x])\n",
+    "print(df.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d14e0424",
+   "metadata": {},
+   "source": [
+    "# Use difference-finder\n",
+    "* Test each dummy (binary) column using a binomial test.\n",
+    "* Test each continuous column using a KS test.\n",
+    "\n",
+    "To Do: KS test is not great. Implement a test of means and a test of medians."
    ]
   }
  ],

--- a/moz_preprocess/preprocess.py
+++ b/moz_preprocess/preprocess.py
@@ -4,7 +4,7 @@ import pandas as pd
 def preprocess(series, series_name, min_count):
     """
     Preprocess a series of discrete data by creating dummy columns for the top 3 most-frequently-occurring values
-    that also occur more than min_count times.
+    that also occur more than min_count times. If only 1 value occurs more than min_count times, return None.
     Args:
     * series (pd.Series): Discrete data to create dummy columns for.
     * series_name (str): Name of `series`. Used to name the dummy columns.

--- a/moz_preprocess/preprocess.py
+++ b/moz_preprocess/preprocess.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+
+def preprocess(series, series_name, min_count):
+    """
+    Preprocess a series of discrete data by creating dummy columns for the top 3 most-frequently-occurring values
+    that also occur more than min_count times.
+    Args:
+    * series (pd.Series): Discrete data to create dummy columns for.
+    * series_name (str): Name of `series`. Used to name the dummy columns.
+    """
+    top_values = get_top_values(series, 3, min_count)
+    if len(top_values) <= 1:
+        return None
+    dummies = pd.get_dummies(series.astype(str))[top_values]
+    dummies.columns = [f"{series_name}_{x}" for x in dummies.columns]
+    return dummies
+
+
+def get_top_values(series, n, min_count):
+    """
+    Return the `n` most-frequently-occurring, non-null values in `series`, that also occur more than `min_count` times.
+    Args:
+    * series (pd.Series): Data to fetch top values in.
+    * n (int): Number of values to return.
+    * min_count (int): Only return values that occur more than min_count times in series.
+    """
+    value_counts = series.astype(str).value_counts().head(n)
+    return value_counts[value_counts > min_count].index.tolist()


### PR DESCRIPTION
Proposed Workflow:

1. Fetch a DataFrame using moz_preprocess.bq_utils.fetch_weekly_aggregate
2. In Python, preprocess columns in the DataFrame, so that they can be used in difference-finder.
    In particular, write functions to preprocess the array, struct, discrete fields. Add them to moz-preprocess.
3. Pass the DataFrame to difference-finder.

This PR adds a function to handle discrete fields in Step 2.

Also -- sorry about doing so much of the development work! I'm only doing this because I need to deliver some results for Suggest Online vs Offline in the near future.